### PR TITLE
feat(sharding): public release_partition_key to free a pool slot

### DIFF
--- a/crates/canic-core/src/api/placement/sharding/mod.rs
+++ b/crates/canic-core/src/api/placement/sharding/mod.rs
@@ -59,4 +59,15 @@ impl ShardingApi {
     ) -> Result<ShardingPlanStateResponse, Error> {
         ShardingWorkflow::plan_assign_to_pool(pool, partition_key).map_err(Error::from)
     }
+
+    /// Release (unassign) a partition_key from its shard, freeing the slot and
+    /// decrementing the shard's load counter. Returns the shard it was assigned
+    /// to, or `None` if it was unassigned. Inverse of [`Self::assign_to_pool`] —
+    /// for pool owners reclaiming stale or never-completed assignments.
+    pub fn release_partition_key(
+        pool: &str,
+        partition_key: impl AsRef<str>,
+    ) -> Result<Option<Principal>, Error> {
+        ShardingWorkflow::release_partition_key(pool, partition_key).map_err(Error::from)
+    }
 }

--- a/crates/canic-core/src/ops/storage/placement/sharding.rs
+++ b/crates/canic-core/src/ops/storage/placement/sharding.rs
@@ -172,6 +172,28 @@ impl ShardingRegistryOps {
         })
     }
 
+    /// Release (unassign) a partition_key from its shard, decrementing that
+    /// shard's derived load counter. Returns the shard the key was assigned to,
+    /// or `None` if the key had no assignment. Inverse of [`Self::assign`]; used
+    /// by eviction / reclamation workflows to free a slot.
+    pub fn release(pool: &str, partition_key: &str) -> Result<Option<Principal>, InternalError> {
+        ShardingRegistry::with_mut(|core| {
+            let key = ShardKey::try_new(pool, partition_key)
+                .map_err(ShardingRegistryOpsError::InvalidKey)?;
+
+            let Some(shard) = core.remove_assignment(&key) else {
+                return Ok(None);
+            };
+
+            if let Some(mut entry) = core.get_entry(&shard) {
+                entry.count = entry.count.saturating_sub(1);
+                core.insert_entry(shard, entry);
+            }
+
+            Ok(Some(shard))
+        })
+    }
+
     /// NOTE:
     /// Returns canonical assignment keys. Callers should not stringify unless required
     /// at an API or DTO boundary.
@@ -221,5 +243,27 @@ mod tests {
         ShardingRegistryOps::assign("poolA", "partition_key1", shard_pid).unwrap();
         let count_after = ShardingRegistryOps::get(shard_pid).unwrap().count;
         assert_eq!(count_after, 1);
+    }
+
+    #[test]
+    fn release_frees_slot_and_decrements_count() {
+        ShardingRegistryOps::clear_for_test();
+        let role = CanisterRole::new("alpha");
+        let shard_pid = p(1);
+
+        ShardingRegistryOps::create(shard_pid, "poolA", 0, &role, 2, 0).unwrap();
+        ShardingRegistryOps::assign("poolA", "pk1", shard_pid).unwrap();
+        assert_eq!(ShardingRegistryOps::get(shard_pid).unwrap().count, 1);
+
+        // Releasing the key returns its shard, drops the assignment, and frees
+        // the slot (count back to 0).
+        let released = ShardingRegistryOps::release("poolA", "pk1").unwrap();
+        assert_eq!(released, Some(shard_pid));
+        assert_eq!(ShardingRegistryOps::get(shard_pid).unwrap().count, 0);
+        assert!(ShardingRegistryOps::partition_key_shard("poolA", "pk1").is_none());
+
+        // Releasing an unknown key is a no-op returning None.
+        assert_eq!(ShardingRegistryOps::release("poolA", "pk1").unwrap(), None);
+        assert_eq!(ShardingRegistryOps::get(shard_pid).unwrap().count, 0);
     }
 }

--- a/crates/canic-core/src/storage/stable/sharding/mod.rs
+++ b/crates/canic-core/src/storage/stable/sharding/mod.rs
@@ -154,7 +154,6 @@ impl<M: Memory> ShardingCore<M> {
         self.assignments.insert(key, shard);
     }
 
-    #[expect(dead_code)] // Used by future rebalance / eviction workflows
     pub fn remove_assignment(&mut self, key: &ShardKey) -> Option<Principal> {
         self.assignments.remove(key)
     }

--- a/crates/canic-core/src/workflow/placement/sharding/mod.rs
+++ b/crates/canic-core/src/workflow/placement/sharding/mod.rs
@@ -295,6 +295,18 @@ impl ShardingWorkflow {
         Ok(ShardingPlanStateResponseMapper::record_to_view(plan.state))
     }
 
+    /// Release (unassign) a partition_key from its shard, freeing the slot and
+    /// decrementing the shard's load counter. Returns the shard the key was
+    /// assigned to, or `None` if it had no assignment. The inverse of
+    /// [`Self::assign_to_pool`]; intended for eviction / reclamation of stale or
+    /// never-completed assignments by a pool owner.
+    pub fn release_partition_key(
+        pool: &str,
+        partition_key: impl AsRef<str>,
+    ) -> Result<Option<Principal>, InternalError> {
+        ShardingRegistryOps::release(pool, partition_key.as_ref())
+    }
+
     fn blocked(reason: CreateBlockedReason, pool: &str, partition_key: &str) -> InternalError {
         ShardingWorkflowError::Policy(ShardingPolicyError::ShardCreationBlocked {
             reason,


### PR DESCRIPTION
## Summary

Adds the inverse of `assign_to_pool` so a pool owner can reclaim a stale or
never-completed partition-key assignment and free its slot:

- `ShardingRegistryOps::release(pool, key)` — removes the partition-key→shard
  assignment and decrements that shard's derived load `count` (mirrors `assign`
  exactly).
- Promoted `ShardingCore::remove_assignment` from `#[expect(dead_code)]` to used.
- Exposed through `ShardingWorkflow::release_partition_key` and the public
  `ShardingApi::release_partition_key`.

Returns the freed shard `Principal`, or `None` if the key had no assignment.

## Motivation

Enables TTL-reclamation of unbacked shard-pool slots in downstream fleets. In
our case (Caelum), an owner is placed into the `tenants` pool at app startup —
before any device-signed proof exists — so an attacker can loop free principals
through the placement entrypoint once each and drive the pool to
`PoolAtCapacity`, permanently wedging onboarding. Per-caller rate-limiting
doesn't help (distinct principals); the fix needs the ability to evict
never-completed assignments, which the storage layer supported
(`remove_assignment`) but no public API exposed.

## Notes

- Self-contained, additive, no behavior change unless a caller invokes the new
  method.
- Unit test asserts `release` frees the slot, decrements `count`, and is a no-op
  for an unknown key.
- Compiles clean; `cargo clippy -p canic-core` is clean.