### PR TITLE
fix(ci): add required maximum_group_placements to test-fleet-install input

### DIFF
--- a/scripts/ci/test-fleet-install.sh
+++ b/scripts/ci/test-fleet-install.sh
@@ -60,6 +60,7 @@ imports = []
 maximum_component_instances = 4
 maximum_registry_bytes = 16777216
 maximum_wasm_store_bytes = 200000000
+maximum_group_placements = 16
 
 [fleet_subnet_roots.limits.cycles_funding]
 window_secs = 3600


### PR DESCRIPTION
## What breaks

`make test-fleet-install` cannot run on `main`.

0.101 added the required immutable root limit `maximum_group_placements`
(`FleetSubnetRootLimits` in `crates/canic-core/src/ids/fleet_topology/mod.rs`,
mirrored by `FleetSubnetRootLimitsDocument` in
`crates/canic-host/src/fleet_install_input/mod.rs`). Neither struct gives the
field a serde default, and both are `deny_unknown_fields`.

The Fleet installation input generated by `scripts/ci/test-fleet-install.sh`
was never updated, so the install aborts during planning, before any effect:

```
install: root install failed during Fleet installation planning: could not decode
Fleet installation input .../canic-test-fleet-input.XXXXXX: TOML parse error at line 26, column 1
   |
26 | [fleet_subnet_roots.limits]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
missing field `maximum_group_placements`
```

`make test-fleet-install` is a required RC gate in
`docs/operations/release-package-install-validation.md` and
`docs/operations/release-validation-matrix.md`, but it is not part of
`.github/workflows/ci.yml`, so nothing caught the drift.

## Fix

One line in the heredoc:

```diff
 [fleet_subnet_roots.limits]
 maximum_component_instances = 4
 maximum_registry_bytes = 16777216
 maximum_wasm_store_bytes = 200000000
+maximum_group_placements = 16
```

`16` matches the documented canonical input in
`docs/architecture/fleet-install-input.md`, `deployments/demos/playground-ic.toml`,
and the value used throughout the PocketIC harness and fixtures. `0` is
reserved as the explicit fence that makes a root ineligible for grouped
placement, so it is not appropriate for the reference install. The script
declares no `component_group_placements`, so the ceiling is not otherwise
constrained.

## Verification

Local managed replica (`icp network start local`), network enrolled with
`canic network enroll local`, then:

- before the change: `make test-fleet-install` exits `2` with the parse error above
- after the change: `make test-fleet-install` exits `0`

The installed fleet is live:

```
$ canic --environment local info subnets test-local
SUBNET                                                            ROOT                          STATUS   POOL   CANISTERS
---------------------------------------------------------------   ---------------------------   ------   ----   ---------
cok7q-...-eae                                                     tz2ag-zx777-77776-aaabq-cai   ACTIVE      0           3

Fleet total: 3 Canisters
```

## Not addressed here

`canic info list <fleet>` and `canic medic fleet <fleet>` still fail on a
Coordinator-anchored fleet ("the removed single-root topology resolver cannot
serve this operation"), which also makes `medic` report `status: fail`. That is
separate from this parse failure and left alone.
